### PR TITLE
links open in a blank page

### DIFF
--- a/app/controllers/user/links_controller.rb
+++ b/app/controllers/user/links_controller.rb
@@ -14,7 +14,7 @@ protect_from_forgery except: :new
     question = Question.find(params[:question_id])
     topic = Topic.find(params[:topic_id])
     link = question.links.create(link_params)
-
+    
     redirect_to user_topic_path(topic)
   end
 

--- a/app/views/partials/_question_show.html.erb
+++ b/app/views/partials/_question_show.html.erb
@@ -14,7 +14,7 @@
     <h3>Bing results</h3>
       <% @facade.bing_search(@facade.current_question).each do |link| %>
         <div class="search_results">
-          <%= link_to "#{link.title}", link.saved_url %> <br>
+          <%= link_to "#{link.title}", link.saved_url, target: "_blank" %> <br>
         </div>
       <%end%>
   </div>


### PR DESCRIPTION
added

links open in a new tab.

also saw that notes form on the topic show is removing the (:) in the url

- [ ] Wrote Tests
- [x] Implemented
- [ x] Reviewed


# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [ ] New feature
- [x] Bug Fix

# Implements/Fixes:
## Description of Changes
* Added: When user  click on links on the topic show page, they open in a new blank page 
closes #

# Check the correct boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

-  [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

# Please include a link to a gif of how you feel about this branch:
